### PR TITLE
Hide changelog link in the footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,10 +16,6 @@ import ThemeSelect from "./ThemeSelect.astro";
                 href="#">Reach support</a>
         </p>
         <p>
-            <Fragment set:html={textArrowIcon} />Latest product
-            updates? - <a href="https://www.daytona.io/changelog">View Changelog</a>
-        </p>
-        <p>
             <Fragment set:html={textArrowIcon} />Dotfiles Insider
             - <a href="https://www.daytona.io/dotfiles/">Read our blog</a>
         </p>

--- a/src/styles/components/docs-footer.scss
+++ b/src/styles/components/docs-footer.scss
@@ -16,6 +16,10 @@
     padding-bottom: 20px;
     margin-bottom: 20px;
 
+    a[href="https://www.daytona.io/changelog"] {
+      visibility: hidden;
+    }
+
     p {
       font-size: 0.75rem;
       line-height: 1.4;

--- a/src/styles/components/docs-footer.scss
+++ b/src/styles/components/docs-footer.scss
@@ -16,7 +16,7 @@
     padding-bottom: 20px;
     margin-bottom: 20px;
 
-    a[href="https://www.daytona.io/changelog"] {
+    a[href="https://www.daytona.io/changelog"] { 
       visibility: hidden;
     }
 

--- a/src/styles/components/docs-footer.scss
+++ b/src/styles/components/docs-footer.scss
@@ -16,9 +16,6 @@
     padding-bottom: 20px;
     margin-bottom: 20px;
 
-    a[href="https://www.daytona.io/changelog"] { 
-      visibility: hidden;
-    }
 
     p {
       font-size: 0.75rem;


### PR DESCRIPTION
Fixes #92 

## Changes 
- In `docs-footer.scss`, hide visibility of  `View Changelog` link  from  `Footer.astro`