### PR TITLE
docs: port astro components from oss docs

### DIFF
--- a/src/components/DocumentList.astro
+++ b/src/components/DocumentList.astro
@@ -1,0 +1,30 @@
+---
+const { title } = Astro.props
+---
+
+<style>
+  section {
+    all: unset;
+  }
+
+  h1 {
+    all: unset;
+    font-family: 'Berkeley Mono', monospace;
+    font-weight: 700;
+    font-size: 2em;
+  }
+
+  ul {
+    all: unset;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+  }
+</style>
+
+<section>
+  <h1>{title}</h1>
+  <ul>
+    <slot />
+  </ul>
+</section>

--- a/src/components/DocumentListItem.astro
+++ b/src/components/DocumentListItem.astro
@@ -1,0 +1,45 @@
+---
+const { href, title, subtitle, expanded } = Astro.props
+
+const gridColumn = expanded ? 'span 2' : 'inherit'
+const style = `grid-column: ${gridColumn};`
+---
+
+<style>
+  a {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--block-bg-color);
+    border: var(--border);
+    border-color: var(--block-bg-color);
+  }
+
+  a:hover {
+    background: var(--secondary-text-color);
+    border-color: var(--secondary-text-color);
+  }
+
+  li {
+    display: inline-block;
+    padding: 1em;
+    width: 100%;
+    height: 100%;
+  }
+
+  .document-title {
+    font-weight: bold;
+  }
+
+  .subtitle {
+    font-weight: normal;
+    font-size: 0.8em;
+  }
+</style>
+
+<a href={href} style={style}>
+  <li>
+    <span class="document-title">{title}</span><br />
+    <span class="subtitle">{subtitle}</span>
+  </li>
+</a>


### PR DESCRIPTION
This pull request ports astro components (DocumentList and DocumentListItem) used in [daytonaio/docs](https://github.com/daytonaio/docs).

These will be useful for creating clickable cards within different sections in the documentation.