### PR TITLE
docs: remove (comment-out) nav buttons

### DIFF
--- a/src/components/menu/SideNavLinks.tsx
+++ b/src/components/menu/SideNavLinks.tsx
@@ -29,17 +29,17 @@ export const SideNavLinks = () => {
   return (
     <>
       <div className="nav-item call">
-        <a
+        {/* <a
           href="https://daytona.zapier.app/"
           target="_blank"
           className="nav__link"
           rel="noreferrer"
         >
           Get a Demo
-        </a>
+        </a> */}
       </div>
       <div className="nav-item github">
-        <a
+        {/* <a
           href="https://github.com/daytonaio/daytona"
           target="_blank"
           className="nav__link"
@@ -63,7 +63,7 @@ export const SideNavLinks = () => {
             : stars === null
             ? 'Star'
             : GITHUB_STARS_FORMATTER.format(stars)}
-        </a>
+        </a> */}
       </div>
     </>
   )


### PR DESCRIPTION
> can you change the link of the main logo to go back to DOMAIN of daytona and remove the GET demo and GITHUB buttons

Removed (commented-out) the navigation bar buttons. The main logo already points to https://www.daytona.io/ - let me know if this should be changed to point to somewhere else.