### PR TITLE
fix: light theme flickering

### DIFF
--- a/src/components/ThemeSelect.astro
+++ b/src/components/ThemeSelect.astro
@@ -67,14 +67,6 @@ import lightThemeIcon from '@assets/icons/light-sun.svg?raw'
         /** Update select menu UI, document theme, and local storage state. */
         #onThemeChange(theme: Theme): void {
             ThemeProvider.updatePickers(theme);
-            const themeFinal = theme === 'auto' ? this.#getPreferredColorScheme() : theme;
-            if (themeFinal === 'light') {
-                document.body.classList.add('light')
-                document.body.classList.remove('dark')
-            } else {
-                document.body.classList.add('dark')
-                document.body.classList.remove('light')
-            }
             document.documentElement.dataset.theme =
                 theme === 'auto' ? this.#getPreferredColorScheme() : theme;
             this.#storeTheme(theme);

--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -25,7 +25,7 @@ body {
   --blue-link: #59acff;
 }
 
-body.light {
+html[data-theme="light"] {
   --bg-color: #fff;
   --border-color: #dedede;
   --border-extra: #dedede;

--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -25,7 +25,7 @@ body {
   --blue-link: #59acff;
 }
 
-html[data-theme="light"] {
+html[data-theme="light"] body {
   --bg-color: #fff;
   --border-color: #dedede;
   --border-extra: #dedede;


### PR DESCRIPTION
Change css style body.light to html[data-theme="light"] body.

Because the script appending className to the body classList is executed after the page is loaded, it causes flickering every time when enter a new page.